### PR TITLE
modify .setOnepx.less

### DIFF
--- a/src/style/base/mixin/setOnepx.less
+++ b/src/style/base/mixin/setOnepx.less
@@ -4,9 +4,7 @@
     left: 0;
     top: 0;
     right: 0;
-    height: 1px;
     border-top: 1px solid @c;
-    color: @c;
     transform-origin: 0 0;
     transform: scaleY(0.5);
 }
@@ -17,9 +15,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    height: 1px;
     border-bottom: 1px solid @c;
-    color: @c;
     transform-origin: 0 100%;
     transform: scaleY(0.5);
 }
@@ -29,10 +25,8 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: 1px;
     bottom: 0;
     border-left: 1px solid @c;
-    color: @c;
     transform-origin: 0 0;
     transform: scaleX(0.5);
 }
@@ -42,10 +36,8 @@
     position: absolute;
     right: 0;
     top: 0;
-    width: 1px;
     bottom: 0;
     border-right: 1px solid @c;
-    color: @c;
     transform-origin: 100% 0;
     transform: scaleX(0.5);
 }


### PR DESCRIPTION
看到 setOnepx.less 中，有如下代码
```
.setTopLine(@c: #C7C7C7) {
  content: " ";
  position: absolute;
  left: 0;
  top: 0;
  right: 0;
  height: 1px;
  border-top: 1px solid @c;
  color: @c;
  transform-origin: 0 0;
  transform: scaleY(0.5);
}
```
如果效果是实现 1px 边框，应该是不用设置 `height: 1px; color: @c` 这两条语句的，所以提了个小小的 PL