### PR TITLE
修改底部状态栏的position属性

### DIFF
--- a/src/style/widget/weui-tab/weui-tabbar.less
+++ b/src/style/widget/weui-tab/weui-tabbar.less
@@ -18,7 +18,7 @@
 
 .weui-tabbar {
     display: flex;
-    position: absolute;
+    position: fixed;
     z-index: 500;
     bottom: 0;
     width: 100%;


### PR DESCRIPTION
底部状态栏应该是固定的，而不应该随页面滑动而移动，应该使用fixed值，而不是absolute